### PR TITLE
bugfix - include path to translations

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@
 const bootstrap = require('hof-bootstrap');
 
 bootstrap({
-	sessionStore: CI ? mockSessionStore : null,
 	translations: './apps/complaints/translations',
 	views: false,
 	fields: false,

--- a/app.js
+++ b/app.js
@@ -3,6 +3,8 @@
 const bootstrap = require('hof-bootstrap');
 
 bootstrap({
+	sessionStore: CI ? mockSessionStore : null,
+	translations: './apps/complaints/translations',
 	views: false,
 	fields: false,
 	routes: [


### PR DESCRIPTION
This was causing an error when rendering terms and cookies pages