### PR TITLE
Use real redis

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,8 @@ pipeline:
       event: pull_request
 
 services:
+  redis:
+    image: redis
   dind:
     image: docker:1.11-dind
     privileged: true

--- a/Dockerfile-acceptance
+++ b/Dockerfile-acceptance
@@ -9,8 +9,9 @@ RUN wget https://github.com/Medium/phantomjs/releases/download/v2.1.1/${PHANTOM_
 
 COPY package.json package.json
 COPY acceptance_tests acceptance_tests/
+COPY apps apps/
 COPY test.sh test.sh
 
-RUN npm --loglevel warn install --only=development --ignore-scripts
+RUN npm --loglevel warn install --ignore-scripts
 
 CMD /test/test.sh

--- a/acceptance_tests/features/applicant-name.js
+++ b/acceptance_tests/features/applicant-name.js
@@ -29,7 +29,7 @@ Scenario('I see the complainant label if I am the complainant', function *(
   yield I.setSessionData('complaints', {
     applicant: 'true'
   });
-  I.refreshPage();
+  yield I.refreshPage();
   I.see(applicantNamePage.complainant);
 });
 
@@ -40,7 +40,7 @@ Scenario('I see the representative label if I am the representative', function *
   yield I.setSessionData('complaints', {
     applicant: 'false'
   });
-  I.refreshPage();
+  yield I.refreshPage();
   I.see(applicantNamePage.representative);
 });
 

--- a/app.js
+++ b/app.js
@@ -2,13 +2,7 @@
 
 const bootstrap = require('hof-bootstrap');
 
-const mockSessionStore = require('hof-acceptance/mock-session');
-const config = require('./config');
-
-const CI = config.env === 'ci';
-
 bootstrap({
-	sessionStore: CI ? mockSessionStore : null,
 	views: false,
 	fields: false,
 	routes: [

--- a/config.js
+++ b/config.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  // eslint-disable-next-line no-process-env
-  env: process.env.NODE_ENV
-};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "so-acceptance": "^1.0.0",
+    "so-acceptance": "^2.0.0",
     "jscs": "^3.0.6",
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.4.0",

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,6 @@
 
 ${PHANTOM_JS}/bin/phantomjs --webdriver=4444&
 
+npm run hof-transpile
+
 npm run test:acceptance


### PR DESCRIPTION
* bumped so-acceptance to 2.0.0
* removed MemoryStore session mocking
* added redis service back to drone