### PR TITLE
Bugfix - UCHV-105 - country validation

### DIFF
--- a/apps/complaints/translations/src/en/validation.json
+++ b/apps/complaints/translations/src/en/validation.json
@@ -93,7 +93,8 @@
     "required": "Select an option"
   },
   "country": {
-    "required": "Enter which country the visa application centre was in"
+    "required": "Enter which country the visa application centre was in",
+    "equal": "Select a country from the list"
   },
   "city": {
     "required": "Enter which city the visa application centre city was in"


### PR DESCRIPTION
Added validation text for "equal" which is added to all select fields by default - need to select an item from the list