### PR TITLE
bugfix - UCHV-121 - summary page label

### DIFF
--- a/apps/complaints/translations/src/en/fields.json
+++ b/apps/complaints/translations/src/en/fields.json
@@ -1,7 +1,6 @@
 {
   "applicant": {
     "legend": "Who are you?",
-    "summary": "I am the",
     "options": {
       "true": {
         "label": "I am the applicant",


### PR DESCRIPTION
* removed summary text from the first field so it reads well on summary page.

This change is necessary due to a change in the confirm controller - it used to show the radio value on summary page but now shows the label.