### PR TITLE
update to hof-bootstrap 9.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "browserify": "^12.0.1",
-    "hof-bootstrap": "^9.3.0",
+    "hof-bootstrap": "^9.3.1",
     "hof-controllers": "^6.0.0",
     "lodash": "^4.17.4",
     "so-acceptance": "^4.2.0",


### PR DESCRIPTION
Update to hof-bootstrap 9.3.1 to enable auto-addition of google-analytics-specific CSP directives, which means the google analytics script can load it's own js and images