### PR TITLE
Update nodejs to latest v6. I updated the nodejs-base to now publish three images on publish:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/nodejs-base:v6.11.1
+FROM quay.io/ukhomeofficedigital/nodejs-base:v6
 
 RUN mkdir /public
 


### PR DESCRIPTION
major
major.minor
and
major.minor.patch

Just following the major version means in the future you don't need to care about updating your base image for security fixes you should just have to rebuild your image.

I did this to stop having to go round and update everything after i release a new base image.