### PR TITLE
HOF-7-existing-complaint-bug

### DIFF
--- a/apps/ukvi-complaints/lib/json-converters/complaint.js
+++ b/apps/ukvi-complaints/lib/json-converters/complaint.js
@@ -76,12 +76,16 @@ const getComplaint = (values) => {
   let data = {
     creationDate: moment().format('YYYY-MM-DD'),
     complaint: {
-      reporterDetails: createReporterDetails(values),
       complaintDetails: {
         complaintText: values['complaint-details']
       }
     }
   };
+
+  if (values['acting-as-agent']) {
+    data.complaint.reporterDetails = createReporterDetails(values);
+  }
+
   if (values['reference-numbers'] && values['reference-numbers'] !== 'none') {
     data.complaint.reference = createReference(values);
   }

--- a/test/unit/lib/json-converters/existing.spec.js
+++ b/test/unit/lib/json-converters/existing.spec.js
@@ -6,12 +6,13 @@ const getExistingComplaint = require('../../../../apps/ukvi-complaints/lib/json-
 
 describe('getExistingComplaint', () => {
   describe('previousComplaint', () => {
-    it('returns existingComplaintreference number if "yes" existing-existingComplaintvalue passed in', () => {
+    it('returns existing complaint reference number if "yes" existing-complaint value passed in', () => {
       const refNumber = '23456789o0p9';
-      const values = Object.assign({
+      const values = {
         'existing-complaint': 'yes',
-        'complaint-reference-number': refNumber
-      }, complaintDetailsBase);
+        'complaint-reference-number': refNumber,
+        'complaint-details': 'test'
+      };
 
       const existingComplaint = getExistingComplaint(values);
       expect(


### PR DESCRIPTION
The existing complaint route was throwing an error because the complaint data formatting functionality was expecting reporter details when they are not required if the user has entered an existing complaint number.

I have moved the reporter details to an optional field only if the 'acting-as-agent' field present with the form data.