### PR TITLE
Hof 6 improve logging

### DIFF
--- a/apps/ukvi-complaints/behaviours/send-to-sqs.js
+++ b/apps/ukvi-complaints/behaviours/send-to-sqs.js
@@ -43,7 +43,7 @@ module.exports = superclass => class SendToSQS extends superclass {
     err.formNotSubmitted = true;
     err.complaintDetails = complaintDetails;
     // eslint-disable-next-line no-console
-    console.error(err);
+    console.error('Failed to send to SQS queue: ', err);
     return next(err);
   }
 

--- a/apps/ukvi-complaints/behaviours/send-to-sqs.js
+++ b/apps/ukvi-complaints/behaviours/send-to-sqs.js
@@ -1,5 +1,6 @@
 'use strict';
 const Validator = require('jsonschema').Validator;
+const { v4: uuidv4 } = require('uuid');
 const config = require('../../../config');
 const { validAgainstSchema, sendToQueue } = require('../lib/utils');
 const formatComplaintData = require('../lib/format-complaint-data');
@@ -8,30 +9,39 @@ module.exports = superclass => class SendToSQS extends superclass {
 
   // eslint-disable-next-line consistent-return
   saveValues(req, res, next) {
+    let complaintId;
+    let complaintData;
+
     try {
       if (!config.sendToQueue) {
         return next();
       }
 
-      const complaintData = formatComplaintData(req.sessionModel.attributes);
+      complaintId = uuidv4();
+      complaintData = formatComplaintData(req.sessionModel.attributes);
 
       if (validAgainstSchema(complaintData, new Validator())) {
-        return sendToQueue(complaintData)
+        return sendToQueue(complaintData, complaintId)
           .then(() => {
             next();
           })
           .catch(err => {
-            SendToSQS.handleError(next, err);
+            SendToSQS.handleError(next, err, complaintId, complaintData);
           });
       }
     } catch (err) {
-      SendToSQS.handleError(next, err);
+      SendToSQS.handleError(next, err, complaintId, complaintData);
     }
   }
 
 
-  static handleError(next, err) {
+  static handleError(next, err, id, data) {
+    const complaintDetails = {
+      complaintId: id,
+      data
+    };
     err.formNotSubmitted = true;
+    err.complaintDetails = complaintDetails;
     // eslint-disable-next-line no-console
     console.error(err);
     return next(err);

--- a/apps/ukvi-complaints/lib/utils.js
+++ b/apps/ukvi-complaints/lib/utils.js
@@ -19,7 +19,7 @@ const validAgainstSchema = (data, validator) => {
 };
 
 
-const sendToQueue = (complaintData) => {
+const sendToQueue = (data, id) => {
   try {
     const producer = Producer.create(config.awsSqs);
 
@@ -27,13 +27,22 @@ const sendToQueue = (complaintData) => {
       producer.send(
         [
           {
-            id: uuidv4(),
-            body: JSON.stringify(complaintData)
+            id,
+            body: JSON.stringify(data)
           }
         ])
       .then((response) => {
+        const log = {
+          sqsResponse: response,
+          complaintDetails: {
+            sqsMessageId: response[0].MessageId,
+            complaintId: id,
+            data
+          }
+        };
+
         // eslint-disable-next-line no-console
-        console.log(response);
+        console.log('Successfully sent to SQS queue', log);
         resolve();
       })
       .catch(error => {
@@ -41,7 +50,7 @@ const sendToQueue = (complaintData) => {
       });
     });
   } catch (err) {
-    throw new Error('Failed to send to queue', err);
+    throw new Error('Failed to send to sqs queue', err);
   }
 };
 

--- a/apps/ukvi-complaints/lib/utils.js
+++ b/apps/ukvi-complaints/lib/utils.js
@@ -1,5 +1,4 @@
 'use strict';
-const { v4: uuidv4 } = require('uuid');
 const { Producer } = require('sqs-producer');
 const config = require('../../../config');
 const decsSchema = require('../schema/decs.json');

--- a/apps/ukvi-complaints/lib/utils.js
+++ b/apps/ukvi-complaints/lib/utils.js
@@ -41,7 +41,7 @@ const sendToQueue = (data, id) => {
         };
 
         // eslint-disable-next-line no-console
-        console.log('Successfully sent to SQS queue', log);
+        console.log('Successfully sent to SQS queue: ', log);
         resolve();
       })
       .catch(error => {

--- a/test/unit/lib/behaviours/send-to-sqs.spec.js
+++ b/test/unit/lib/behaviours/send-to-sqs.spec.js
@@ -14,6 +14,10 @@ describe('SendToSQS', () => {
   let formatComplaintDataStub;
   let sendToQueueStub;
   let validAgainstSchemaStub;
+  let uuidStub;
+
+  const testUuid = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d';
+
   const complaintData = {
     data: 'test'
   };
@@ -45,6 +49,8 @@ describe('SendToSQS', () => {
 
     nextStub = sinon.stub();
 
+    uuidStub = sinon.stub().returns(testUuid);
+
     validAgainstSchemaStub = sinon.stub().returns(true);
 
     formatComplaintDataStub = sinon.stub().returns(complaintData);
@@ -52,8 +58,8 @@ describe('SendToSQS', () => {
     formatComplaintDataStub.withArgs(badDataReq.sessionModel.attributes).returns(badComplaintData);
 
     sendToQueueStub = sinon.stub();
-    sendToQueueStub.withArgs(complaintData).resolves();
-    sendToQueueStub.withArgs(badComplaintData).rejects(testError);
+    sendToQueueStub.withArgs(complaintData, testUuid).resolves();
+    sendToQueueStub.withArgs(badComplaintData, testUuid).rejects(testError);
 
     const Behaviour = proxyquire('../../../../apps/ukvi-complaints/behaviours/send-to-sqs', {
       '../../../config': {
@@ -62,6 +68,9 @@ describe('SendToSQS', () => {
       '../lib/utils': {
         validAgainstSchema: validAgainstSchemaStub,
         sendToQueue: sendToQueueStub,
+      },
+      'uuid': {
+        v4: uuidStub
       },
       '../lib/format-complaint-data': formatComplaintDataStub
     });
@@ -89,10 +98,10 @@ describe('SendToSQS', () => {
           }
         );
 
-        const SendToQueue = SQSBehaviour(Base);
-        const sendToQueue = new SendToQueue();
+        const SendToSQSBehaviour = SQSBehaviour(Base);
+        const sendToSQSBehaviour = new SendToSQSBehaviour();
 
-        sendToQueue.saveValues(req, res, nextStub);
+        sendToSQSBehaviour.saveValues(req, res, nextStub);
 
         expect(sendToQueueStub).to.have.callCount(0);
 

--- a/test/unit/lib/utils.spec.js
+++ b/test/unit/lib/utils.spec.js
@@ -7,7 +7,6 @@ describe('utils', () => {
   let utils;
   let createSub;
   let sendStub;
-  let uuidStub;
   let testSchema = {
     'test': 'schema'
   };
@@ -48,7 +47,6 @@ describe('utils', () => {
 
 
   beforeEach(() => {
-    uuidStub = sinon.stub().returns(testUuid);
     sendStub = sinon.stub().resolves();
     sendStub.withArgs({
       id: testUuid,
@@ -63,9 +61,6 @@ describe('utils', () => {
         Producer: {
           create: createSub
         }
-      },
-      'uuid': {
-        v4: uuidStub
       },
       '../schema/decs.json': testSchema
     });
@@ -114,7 +109,7 @@ describe('utils', () => {
   describe('#sendToQueue', () => {
 
     it('calls create on the sqs producer with SQS parameters', () => {
-      utils.sendToQueue(validComplaintData);
+      utils.sendToQueue(validComplaintData, testUuid);
       expect(createSub).to.have.been.calledOnceWith({
         queueUrl: 'http://localhost:4566/000000000000/local-queue',
         region: 'eu-west-2',
@@ -124,7 +119,7 @@ describe('utils', () => {
     });
 
     it('calls send on sqs producer with a unique id and stringifyed complaint data', () => {
-      utils.sendToQueue(validComplaintData);
+      utils.sendToQueue(validComplaintData, testUuid);
       expect(sendStub).to.have.been.calledOnceWith(
         [
           {


### PR DESCRIPTION
Added more detailed logging on both successful and failed complaints submissions. The complaint ID, complaint details and a descriptive message is now logged out. This should make it easier to find and identify any issues if a complaint fails to submit.