### PR TITLE
HOF-9-on/off-decs-integration-toggle

### DIFF
--- a/config.js
+++ b/config.js
@@ -28,5 +28,5 @@ module.exports = {
     accessKeyId: process.env.ACCESS_KEY_ID || '',
     secretAccessKey: process.env.SECRET_ACCESS_KEY || '',
   },
-  sendToQueue: process.env.SEND_TO_DECS_QUEUE === 'true',
+  sendToQueue: process.env.SEND_TO_DECS_QUEUE === 'on',
 };


### PR DESCRIPTION
Change to use on/off toggle instead of true false as kubernetes config map does not work with boolean values