### PR TITLE
SD-235: Fix cookie banner

### DIFF
--- a/apps/ukvi-complaints/index.js
+++ b/apps/ukvi-complaints/index.js
@@ -11,6 +11,10 @@ const caseworkerEmailer = require('./behaviours/caseworker-email')(config.email)
 module.exports = {
   name: 'ukvi-complaints',
   baseUrl: '/',
+  pages: {
+    '/terms-and-conditions': 'terms',
+    '/cookies': 'cookies',
+  },
   steps: {
     '/reason': {
       fields: ['reason'],

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -6,5 +6,7 @@
   "session": {
     "name": "hod.sid",
     "ttl": 3600
-  }
+  },
+  "getCookies": false,
+  "getTerms": false
 }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ app.use((req, res, next) => {
     { path: '/terms-and-conditions', property: 'base.terms' }
   ];
   // set service name for cookie banner
-  res.locals.serviceName = 'UKVI Complaints';
+  res.locals.serviceName = 'UK Visas and Immigration complaints';
   next();
 });
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,22 @@ const addDynamicSettings = (settings) => {
 const app = hof(addDynamicSettings(require('./hof.settings')));
 
 app.use((req, res, next) => {
+  res.locals.footerSupportLinks = [
+    { path: '/cookies', property: 'base.cookies' },
+    { path: '/terms-and-conditions', property: 'base.terms' }
+  ];
   // set service name for cookie banner
   res.locals.serviceName = 'UKVI Complaints';
+  next();
+});
+
+app.use('/cookies', (req, res, next) => {
+  res.locals = Object.assign({}, res.locals, req.translate('cookies'));
+  next();
+});
+
+app.use('/terms-and-conditions', (req, res, next) => {
+  res.locals = Object.assign({}, res.locals, req.translate('terms'));
   next();
 });
 


### PR DESCRIPTION
### What
Update title in cookie banner to match the service title
Update app to ensure locals are available on /cookies and /terms-and-conditions pages so the service title is shown in the cookie banner