### PR TITLE
SD-994: Update config file to remove stub as transport option

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ module.exports = {
   email: {
     from: process.env.FROM_ADDRESS || 'stub@stub.com',
     replyTo: process.env.REPLY_TO || 'stub@stub.com',
-    transport: process.env.EMAIL_TRANSPORT || 'stub',
+    transport: process.env.EMAIL_TRANSPORT || 'ses',
     caseworker: process.env.CASEWORKER_EMAIL || 'stub@stub.com',
     recipient: process.env.CASEWORKER_EMAIL || 'stub@stub.com',
     transportOptions: {


### PR DESCRIPTION
### What
Update config file to change fallback transport option from 'stub' to 'ses'

### Why
The kube files do not include any email transport settings, meaning dev is using the fallback option