### PR TITLE
Upgraded hof-middlware to v2.2.4 to fix redirection to malicious site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3127,9 +3127,9 @@
       }
     },
     "hof-middleware": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/hof-middleware/-/hof-middleware-2.2.3.tgz",
-      "integrity": "sha512-Oiwuy60inZQy4rjoWVcYtseJ8EaF5y40iuumWMaQ0MTjewq+9rgmFzATMBT51gnDlADn9esWTZH5Yuf06HwVuQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/hof-middleware/-/hof-middleware-2.2.4.tgz",
+      "integrity": "sha512-XtuxxVyeJGkdtoh+dz0NfiBlDx9tgTvfAub2flO/U984LPgr0lLOGFhIzxFA0uChNup9tMv0ehsWV9qDzCLBRA==",
       "requires": {
         "lodash": "^4.13.1",
         "urijs": "^1.19.2"
@@ -5993,9 +5993,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
-      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "url": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "hof-behaviour-summary-page": "^3.3.0",
     "hof-build": "^2.0.0",
     "hof-component-date": "^1.4.0",
+    "hof-middleware": "^2.2.4",
     "hof-theme-govuk": "^5.2.4",
     "hof-util-countries": "^1.0.0",
     "jquery": "^3.6.0",


### PR DESCRIPTION
**What**  
Upgraded hof-middlware to v2.2.4
**Why**  
Applications using this library could be vulnerable to a redirection exploit where an attacker can use a Home Office page to redirect someone to their malicious site
**How**  
In hof-middleware ensure URLs are relative paths – i.e. they start with a single / character. Absolute URLs starting with // will be rejected.
**Test**  
Unit test and url test 