### PR TITLE
Unhide VAC Country field

### DIFF
--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -321,7 +321,7 @@ module.exports = {
     mixin: 'select',
     options: [{ label: ' ', value: '' }].concat(require('hof-util-countries')()),
     validate: ['required', { type: 'maxlength', arguments: 100 }],
-    className: ['typeahead', 'js-hidden']
+    className: ['typeahead']
   },
 
   'vac-city': {


### PR DESCRIPTION
### What
Unhide VAC country field by removing the 'js-hidden' class