### PR TITLE
Add missing text to DECS message

### DIFF
--- a/lib/json-converters/delays.js
+++ b/lib/json-converters/delays.js
@@ -9,7 +9,7 @@ const getDelaysComplaint = values => {
     values[delayType], delayType
   );
 
-  data.complaint.complaintDetails.applicationSubmittedWhen = values['when-applied']
+  data.complaint.complaintDetails.applicationSubmittedWhen = values['when-applied'];
 
   const returnOfDocuments = 'return-of-documents';
   if (values[returnOfDocuments]) {

--- a/lib/json-converters/delays.js
+++ b/lib/json-converters/delays.js
@@ -9,6 +9,8 @@ const getDelaysComplaint = values => {
     values[delayType], delayType
   );
 
+  data.complaint.complaintDetails.applicationSubmittedWhen = values['when-applied']
+
   const returnOfDocuments = 'return-of-documents';
   if (values[returnOfDocuments]) {
     data.complaint.complaintDetails.documentReturnRequest = complaint.getFormattedEnum(


### PR DESCRIPTION
**What**
Added the answer to the webform question "When did you submit your application?" To the message sent to SQS

**Why**
Information entered for webform question "When did you submit your application?" is not visible in DECS

**How**
Updated the SQS complaint message to include the missing info.

**Test**
Submit a ‘Waiting for a decision or documents’ complaint and check on DECS if the ‘When did you submit your application?’ Info is present
