### PR TITLE
Changed kube secrets to dev to deploy to preprod

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -291,9 +291,9 @@ steps:
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
     environment:
       KUBE_SERVER:
-        from_secret: kube_server_stg
+        from_secret: kube_server_dev
       KUBE_TOKEN:
-        from_secret: kube_token_stg
+        from_secret: kube_token_dev
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:


### PR DESCRIPTION
What
Changed staging deployment env secret names to kube_server_dev and kube_token_dev 

Why
The improved pipeline changes had the names as kube_server_stg and kube_token_stg which has not been added to the preprod namespace. While a request is made to ACP this is temporary fix to deploy to preprod
