### PR TITLE
UKVIC-118: Add nonUrl validations to name fields

### DIFF
--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -351,7 +351,7 @@ module.exports = {
   },
   'called-number': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -375,7 +375,7 @@ module.exports = {
   },
   'called-from': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -547,7 +547,7 @@ module.exports = {
 
   'agent-phone': {
     mixin: 'input-text',
-    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -613,7 +613,7 @@ module.exports = {
 
   'applicant-phone': {
     mixin: 'input-text',
-    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },

--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -530,7 +530,7 @@ module.exports = {
 
   'agent-name': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 150 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 150 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -557,7 +557,7 @@ module.exports = {
 
   'applicant-name': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -598,7 +598,7 @@ module.exports = {
 
   'agent-representative-name': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
     legend: {
       className: 'visuallyhidden'
     },

--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -326,7 +326,7 @@ module.exports = {
 
   'vac-city': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
     legend: {
       className: 'visuallyhidden'
     }
@@ -334,7 +334,7 @@ module.exports = {
 
   'ssc-city': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -343,7 +343,7 @@ module.exports = {
 
   'ukvcas-city': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -351,7 +351,7 @@ module.exports = {
   },
   'called-number': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -359,7 +359,7 @@ module.exports = {
   },
   'called-date': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -367,7 +367,7 @@ module.exports = {
   },
   'called-time': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -375,7 +375,7 @@ module.exports = {
   },
   'called-from': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -452,7 +452,7 @@ module.exports = {
     }]
   },
   'gwf-reference': {
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
     dependent: {
       field: 'reference-numbers',
       value: 'gwf'
@@ -463,25 +463,25 @@ module.exports = {
       field: 'reference-numbers',
       value: 'ho'
     },
-    validate: ['required', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
   },
   'ihs-reference': {
     dependent: {
       field: 'reference-numbers',
       value: 'ihs'
     },
-    validate: ['required', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
   },
   'uan-reference': {
     dependent: {
       field: 'reference-numbers',
       value: 'uan'
     },
-    validate: ['required', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
   },
   'when-applied': {
     mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 50 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -490,7 +490,7 @@ module.exports = {
 
   'complaint-reference-number': {
     mixin: 'input-text',
-    validate: [{ type: 'maxlength', arguments: 100 }]
+    validate: ['notUrl', { type: 'maxlength', arguments: 100 }]
   },
   'complaint-details': {
     mixin: 'textarea',
@@ -548,7 +548,7 @@ module.exports = {
 
   'agent-phone': {
     mixin: 'input-text',
-    validate: [{ type: 'maxlength', arguments: 50 }],
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },
@@ -614,7 +614,7 @@ module.exports = {
 
   'applicant-phone': {
     mixin: 'input-text',
-    validate: [{ type: 'maxlength', arguments: 50 }],
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: 50 }],
     legend: {
       className: 'visuallyhidden'
     },

--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -411,7 +411,6 @@ module.exports = {
     validate: 'required'
   },
 
-
   'other-complaint': {
     mixin: 'radio-group',
     validate: 'required',

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -453,7 +453,7 @@
 		"hint": "For international numbers include the country code",
 		"validation": {
 			"required": "Enter a valid telephone number",
-      "internationalPhoneNumber": "Enter a valid telephone number"
+      "notUrl": "Enter a valid telephone number"
     }
 	},
 	"called-date": {
@@ -477,7 +477,7 @@
 		"hint": "For international numbers include the country code",
 		"validation": {
 			"required": "Enter a valid telephone number",
-      "internationalPhoneNumber": "Enter a valid telephone number"
+      "notUrl": "Enter a valid telephone number"
     }
 	},
 	"existing-complaint": {
@@ -614,7 +614,7 @@
 		"label": "Phone number (optional)",
 		"hint": "We may call if we need more information ",
 		"validation": {
-			"internationalPhoneNumber": "Enter a valid phone number"
+			"notUrl": "Enter a valid phone number"
 		}
 	},
 	"agent-representative-name": {
@@ -672,7 +672,7 @@
 		"legend": "",
 		"label": "Phone number (optional)",
 		"validation": {
-			"internationalPhoneNumber": "Enter a valid phone number"
+			"notUrl": "Enter a valid phone number"
 		}
 	}
 }

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -162,28 +162,32 @@
 		"label": "Enter GWF number",
 		"hint": "For example, GWF012345678.",
 		"validation": {
-			"required": "Enter the GWF number"
+			"required": "Enter the GWF number",
+			"notUrl": "Enter the GWF number"
 		}
 	},
 	"ho-reference": {
 		"label": "Enter Home Office reference number",
 		"hint": "For example, 012345678",
 		"validation": {
-			"required": "Enter the Home Office reference number"
+			"required": "Enter the Home Office reference number",
+			"notUrl": "Enter the Home Office reference number"
 		}
 	},
 	"ihs-reference": {
 		"label": "Enter IHS number",
 		"hint": "For example, IHS123456789",
 		"validation": {
-			"required": "Enter the IHS number"
+			"required": "Enter the IHS number",
+			"notUrl": "Enter the IHS number"
 		}
 	},
 	"uan-reference": {
 		"label": "Enter Unique Application Number",
 		"hint": "For example, 1234-5678-9123-4567",
 		"validation": {
-			"required": "Enter the Unique Application Number"
+			"required": "Enter the Unique Application Number",
+			"notUrl": "Enter the Unique Application Number"
 		}
 	},
 	"agent-representative-dob": {
@@ -426,42 +430,53 @@
   "vac-city": {
     "label": "City",
     "validation": {
-      "required": "Enter the city the visa application centre is in"
+      "required": "Enter the city the visa application centre is in",
+			"notUrl": "Enter the city the visa application centre is in"
     }
   },
   "ssc-city": {
     "label": "City",
     "validation": {
-      "required": "Enter the city the service support centre is in"
+      "required": "Enter the city the service support centre is in",
+			"notUrl": "Enter the city the service support centre is in"
     }
   },
   "ukvcas-city": {
     "label": "City",
     "validation": {
-      "required": "Enter the city the service point is in"
+      "required": "Enter the city the service point is in",
+			"notUrl": "Enter the city the service point is in"
     }
   },
 	"called-number": {
 		"label": "Telephone number",
-		"hint": "For international numbers include the country code"
+		"hint": "For international numbers include the country code",
+		"validation": {
+      "internationalPhoneNumber": "Enter a valid telephone number"
+    }
 	},
 	"called-date": {
 		"label": "Date of the call",
 		"hint": "For example, 30 April or early June",
 		"validation": {
-			"required": "Enter the date of the call"
+			"required": "Enter the date of the call",
+			"notUrl": "Enter the date of the call"
 		}
 	},
 	"called-time": {
 		"label": "Time of the call",
 		"hint": "For example, 10:30am or morning",
 		"validation": {
-			"required": "Enter the time of the call"
+			"required": "Enter the time of the call",
+			"notUrl": "Enter the time of the call"
 		}
 	},
 	"called-from": {
 		"label": "Telephone number",
-		"hint": "For international numbers include the country code"
+		"hint": "For international numbers include the country code",
+		"validation": {
+      "internationalPhoneNumber": "Enter a valid telephone number"
+    }
 	},
 	"existing-complaint": {
 		"options": {
@@ -512,11 +527,17 @@
 		}
 	},
 	"complaint-reference-number": {
-		"label": " "
+		"label": " ",
+		"validation": {
+			"notUrl": "Enter the reference number for your complaint "
+		}
 	},
 	"when-applied": {
 		"label": " ",
-		"hint": "If you can't remember the exact date, just provide the month."
+		"hint": "If you can't remember the exact date, just provide the month.",
+		"validation": {
+			"notUrl": "Enter when you submitted you application "
+		}
 	},
 	"complaint-details": {
 		"label": "Complaint details",
@@ -589,7 +610,10 @@
 	"agent-phone": {
 		"legend": "",
 		"label": "Phone number (optional)",
-		"hint": "We may call if we need more information "
+		"hint": "We may call if we need more information ",
+		"validation": {
+			"internationalPhoneNumber": "Enter a valid phone number"
+		}
 	},
 	"agent-representative-name": {
 		"legend": "",
@@ -644,6 +668,9 @@
 	},
 	"applicant-phone": {
 		"legend": "",
-		"label": "Phone number (optional)"
+		"label": "Phone number (optional)",
+		"validation": {
+			"internationalPhoneNumber": "Enter a valid phone number"
+		}
 	}
 }

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -574,7 +574,8 @@
 		"legend": "",
 		"label": "Full name",
 		"validation": {
-			"required": "Enter your name"
+			"required": "Enter your full name",
+			"notUrl": "Enter your full name"
 		}
 	},
 	"agent-email": {
@@ -594,7 +595,8 @@
 		"legend": "",
 		"label": "Applicant’s full name",
 		"validation": {
-			"required": "Enter the applicant's full name"
+			"required": "Enter the applicant's full name",
+			"notUrl": "Enter the applicant's full name"
 		}
 	},
 	"agent-representative-nationality": {
@@ -609,7 +611,8 @@
 		"legend": "",
 		"label": "Full name",
 		"validation": {
-			"required": "Enter your name"
+			"required": "Enter your full name", 
+			"notUrl":"Enter your full name"
 		}
 	},
 	"applicant-dob": {

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -452,6 +452,7 @@
 		"label": "Telephone number",
 		"hint": "For international numbers include the country code",
 		"validation": {
+			"required": "Enter a valid telephone number",
       "internationalPhoneNumber": "Enter a valid telephone number"
     }
 	},
@@ -475,6 +476,7 @@
 		"label": "Telephone number",
 		"hint": "For international numbers include the country code",
 		"validation": {
+			"required": "Enter a valid telephone number",
       "internationalPhoneNumber": "Enter a valid telephone number"
     }
 	},


### PR DESCRIPTION
What?

Added 'notUrl' validation to three input fields asking for names in UKVIC. Also added error messages when the 'notUrl' validation is triggered.

Why?

These input fields are currently accepting urls.

Testing? 

Tested locally. 