### PR TITLE
UKVIC-117: The language of the document is not identified or a lang attribute value is invalid

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,5 +12,9 @@ if (process.env.REDIS_URL) {
 }
 
 const app = hof(settings);
+app.use((req, res, next) => {
+  res.locals.htmlLang = 'en';
+  next();
+});
 
 module.exports = app;


### PR DESCRIPTION
**Changes**	

- server.js updated to include htmlLang as 'en'
- Retested using the wave tool and is now shown as correct. 

