### PR TITLE
UKVIC-159: Updated HOF to verion 19.13.9, to mitigate error in firefox when fields are not highlighted correctly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postinstall": "yarn run build"
   },
   "dependencies": {
-    "hof": "^19.12.0",
+    "hof": "^19.13.9",
     "hot-shots": "^8.5.0",
     "jquery": "^3.6.0",
     "jsonschema": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,10 +3581,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^19.12.0:
-  version "19.13.4"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.4.tgz#c372ad3d633bfd578d998fdc2f2a3e5c221a0cb1"
-  integrity sha512-lE0sPstSyF4InjHMMxBkEm4yB+OqsM9YDJCQnlVAEp3usyDB2v5ODDw1wwmXR4UGnwFBCiL8EnwOJuEhv9icVg==
+hof@^19.13.9:
+  version "19.13.9"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.9.tgz#28f1385507ac0b2ade993682a76a7c358c76022d"
+  integrity sha512-lSIenKPI5rE1OgTCAJnnMv4mQPWxCXrxjBV5PrfqwDLkLpjz2zlP83xRg/X5jiU4WaRZf9bJfklNiI4NCaOuSQ==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"


### PR DESCRIPTION
**Changes**

- Updated HOF in package.json to version 19.13.9, which contains correction in firefox to focus and highlight fields correctly.