### PR TITLE
Removed outdated call charges info as the link contains the latest charges

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -26,4 +26,8 @@ ignore:
      - '*':
         reason: No direct upgrade or patch
         expires: '2022-11-01T17:02:21.865Z'
+  SNYK-JS-MINIMIST-2429795:
+   - '*':
+        reason: low severity
+        expires: '2022-11-01T17:02:21.865Z'
 patch: {}

--- a/apps/ukvi-complaints/views/content/en/contact-ukvi-outside.md
+++ b/apps/ukvi-complaints/views/content/en/contact-ukvi-outside.md
@@ -2,12 +2,8 @@
 
 You can phone or email to get some help.
 
-Calls cost £1.37 per minute on top of your standard network charges.
-
-Emails cost £5.48. You will not be charged for any follow-up emails about the same enquiry.
+[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
 
 You’ll get a reply to your email within 2 days, except on Saturdays, Sundays and UK public holidays.
 
-
-[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
 

--- a/apps/ukvi-complaints/views/content/en/positive-outcome-outside.md
+++ b/apps/ukvi-complaints/views/content/en/positive-outcome-outside.md
@@ -2,11 +2,7 @@
 
 You can check your visa entitlements by contacting UKVI by phone or email.
 
-Calls cost £1.37 per minute on top of your standard network charges.
-
-Email enquiries cost £5.48. You will not be charged for any follow-up emails about the same enquiry.
+[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
 
 You will get a reply to your email within 2 days, except on Saturdays, Sundays and UK public holidays.
-
-[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
 

--- a/apps/ukvi-complaints/views/content/en/refund-ihs-outside.md
+++ b/apps/ukvi-complaints/views/content/en/refund-ihs-outside.md
@@ -1,4 +1,4 @@
-This should be issued automatically within 6 weeks of getting a decision on your visa. Please wait. 
+This should be issued automatically within 6 weeks of getting a decision on your visa. Please wait.
 
 [Find more about IHS refunds on GOV.UK](https://www.gov.uk/healthcare-immigration-application/refunds)
 
@@ -6,10 +6,8 @@ This should be issued automatically within 6 weeks of getting a decision on your
 
 If you have not received your refund after 6 weeks, you can phone or email to get some help.
 
-Calls cost £1.37 per minute on top of your standard network charges.
-
-Emails cost £5.48. You will not be charged for any follow-up emails about the same enquiry.
+[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
 
 You’ll get a reply to your email within 2 days, except on Saturdays, Sundays and UK public holidays.
 
-[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
+

--- a/apps/ukvi-complaints/views/content/en/refund-priority-outside.md
+++ b/apps/ukvi-complaints/views/content/en/refund-priority-outside.md
@@ -2,10 +2,6 @@ Find out [how soon to expect a decision](https://www.gov.uk/faster-decision-visa
 
 ## Request a refund
 
-Calls cost £1.37 per minute on top of your standard network charges.
-
-Emails cost £5.48. You will not be charged for any follow-up emails about the same enquiry.
+[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
 
 You’ll get a reply to your email within 2 days, except on Saturdays, Sundays and UK public holidays.
-
-[Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)

--- a/apps/ukvi-complaints/views/content/en/refund-super-priority-outside.md
+++ b/apps/ukvi-complaints/views/content/en/refund-super-priority-outside.md
@@ -2,12 +2,8 @@ Find out [how soon to expect a decision](https://www.gov.uk/faster-decision-visa
 
 ## Request a refund
 
-You can phone or email UK Visas and Immigration to ask for a refund. 
-
-Calls cost £1.37 per minute on top of your standard network charges.
-
-Emails cost £5.48. You will not be charged for any follow-up emails about the same enquiry.
-
-You’ll get a reply to your email within 2 days, except on Saturdays, Sundays and UK public holidays.
+You can phone or email UK Visas and Immigration to ask for a refund.
 
 [Contact UK Visas and Immigration](https://www.gov.uk/contact-ukvi-inside-outside-uk)
+
+You’ll get a reply to your email within 2 days, except on Saturdays, Sundays and UK public holidays.


### PR DESCRIPTION
**What**
Removed outdated call charges, the 'Contact UK Visas and Immigration' link has the latest charges.

**Why**
The call charges were out of date.

**How**
Removed call charges in the following pages:
/application-technical-outside-uk
/application-guidance-outside-uk
/appointment-technical-outside
/questions-appointments-outside
/positive-outcome-outside
/refund-priority-outside
/refund-super-priority-outside
/refund-ihs-outside

**Test**
Tested manually.