### PR TITLE
Add additional reference numbers to Refund route

### DIFF
--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -6,32 +6,14 @@ const moment = require('moment');
 module.exports = {
   reason: {
     mixin: 'radio-group',
-    options: [
-      'immigration-application',
-      'immigration-appointment',
-      'delays',
-      'immigration-decision',
-      'biometric-residence-permit',
-      'refund',
-      'staff-behaviour',
-      'existing-complaint',
-      'other-complaint'
-    ],
+    options: ['immigration-application', 'immigration-appointment', 'delays', 'immigration-decision', 'biometric-residence-permit', 'refund', 'staff-behaviour', 'existing-complaint', 'other-complaint'],
     validate: 'required'
   },
 
   'immigration-application': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'technical-issues',
-      'guidance',
-      'complain'
-    ]
+    }, className: ['form-group'], options: ['technical-issues', 'guidance', 'complain']
   },
 
   'immigration-appointment': {
@@ -41,77 +23,35 @@ module.exports = {
       className: 'visuallyhidden'
     },
     className: ['form-group'],
-    options: [
-      'lack-availability',
-      'change-appointment',
-      'technical-appointments',
-      'questions-appointments',
-      'complain-appointments'
-    ]
-  },
-  'where-applied-from': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    options: ['lack-availability', 'change-appointment', 'technical-appointments', 'questions-appointments', 'complain-appointments']
+  }, 'where-applied-from': {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'inside-uk',
-      'outside-uk'
-    ]
+    }, className: ['form-group'], options: ['inside-uk', 'outside-uk']
   },
 
   'delay-type': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'application-delay',
-      'return-of-documents'
-    ]
+    }, className: ['form-group'], options: ['application-delay', 'return-of-documents']
   },
 
   'application-delay': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'request-upgrade',
-      'application-ref-numbers'
-    ]
+    }, className: ['form-group'], options: ['request-upgrade', 'application-ref-numbers']
   },
 
   delays: {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'delay-decision',
-      'delay-docs'
-    ]
+    }, className: ['form-group'], options: ['delay-decision', 'delay-docs']
   },
 
   'have-reference-numbers': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes',
-      'no'
-    ]
+    }, className: ['form-group'], options: ['yes', 'no']
   },
 
   // 'reference-numbers': {
@@ -129,498 +69,288 @@ module.exports = {
   // },
 
   'requested-documents': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes',
-      'no'
-    ]
+    }, className: ['form-group'], options: ['yes', 'no']
   },
 
   'have-requested': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'used-service',
-      'something-else'
-    ]
+    }, className: ['form-group'], options: ['used-service', 'something-else']
   },
 
   'return-of-documents': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes-docs-service',
-      'yes-other',
-      'no'
-    ]
+    }, className: ['form-group'], options: ['yes-docs-service', 'yes-other', 'no']
   },
 
   'immigration-decision': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes',
-      'no'
-    ]
+    }, className: ['form-group'], options: ['yes', 'no']
   },
 
   'decision-outcome': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'negative',
-      'positive'
-    ]
+    }, className: ['form-group'], options: ['negative', 'positive']
   },
 
   'immigration-status-change': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'questions-status-change',
-      'complain-status-change'
-    ]
+    }, className: ['form-group'], options: ['questions-status-change', 'complain-status-change']
   },
 
   'biometric-residence-permit': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'card-not-arrived',
-      'card-incorrect',
-      'complain-brp'
-    ]
+    }, className: ['form-group'], options: ['card-not-arrived', 'card-incorrect', 'complain-brp']
   },
 
   'refund-type': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'standard',
-      'priority',
-      'super-priority',
-      'premium',
-      'ihs',
-      'eu-settlement'
-    ]
+    }, className: ['form-group'], options: ['standard', 'priority', 'super-priority', 'premium', 'ihs', 'eu-settlement']
   },
 
   'refund-type-automatic': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'ihs',
-      'eu-settlement'
-    ]
+    }, className: ['form-group'], options: ['ihs', 'eu-settlement']
   },
 
   refund: {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes',
-      'no',
-      'not-yet'
-    ]
-  },
-  'refund-when': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    }, className: ['form-group'], options: ['yes', 'no', 'not-yet']
+  }, 'refund-when': {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'less-than',
-      'more-than'
-    ]
-  },
-  'staff-behaviour': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    }, className: ['form-group'], options: ['less-than', 'more-than']
+  }, 'staff-behaviour': {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'face-to-face',
-      'on-phone',
-      'in-letter'
-    ]
+    }, className: ['form-group'], options: ['face-to-face', 'on-phone', 'in-letter']
   },
 
   'which-centre': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'vac',
-      'ssc',
-      'ukvcas'
-    ]
+    }, className: ['form-group'], options: ['vac', 'ssc', 'ukvcas']
   },
 
   'vac-country': {
     mixin: 'select',
-    options: [{ label: ' ', value: '' }].concat(require('hof').utils.countries()),
-    validate: ['required', { type: 'maxlength', arguments: 100 }],
+    options: [{label: ' ', value: ''}].concat(require('hof').utils.countries()),
+    validate: ['required', {type: 'maxlength', arguments: 100}],
     className: ['typeahead']
   },
 
   'vac-city': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}], legend: {
       className: 'visuallyhidden'
     }
   },
 
   'ssc-city': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group']
+    }, className: ['form-group']
   },
 
   'ukvcas-city': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group']
-  },
-  'called-number': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    }, className: ['form-group']
+  }, 'called-number': {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group']
-  },
-  'called-date': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    }, className: ['form-group']
+  }, 'called-date': {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group']
-  },
-  'called-time': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    }, className: ['form-group']
+  }, 'called-time': {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group']
-  },
-  'called-from': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    }, className: ['form-group']
+  }, 'called-from': {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group']
+    }, className: ['form-group']
   },
 
   'existing-complaint': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes',
-      'no'
-    ]
+    }, className: ['form-group'], options: ['yes', 'no']
   },
 
   'complaint-reason-previous': {
     mixin: 'radio-group',
-    options: [
-      'immigration-application',
-      'immigration-appointment',
-      'delays',
-      'immigration-decision',
-      'immigration-status-change',
-      'biometric-residence-permit',
-      'refund',
-      'staff-behaviour',
-      'other-complaint'
-    ],
+    options: ['immigration-application', 'immigration-appointment', 'delays', 'immigration-decision', 'immigration-status-change', 'biometric-residence-permit', 'refund', 'staff-behaviour', 'other-complaint'],
     validate: 'required'
   },
 
   'other-complaint': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'technical-issues',
-      'questions',
-      'complain'
-    ]
-  },
-  'reference-numbers': {
-    mixin: 'radio-group',
-    legend: {
+    }, className: ['form-group'], options: ['technical-issues', 'questions', 'complain']
+  }, 'reference-numbers': {
+    mixin: 'radio-group', legend: {
       className: 'visuallyhidden'
-    },
-    validate: 'required',
-    options: [{
-      value: 'gwf',
-      toggle: 'gwf-reference',
-      child: 'input-text'
+    }, validate: 'required', options: [{
+      value: 'gwf', toggle: 'gwf-reference', child: 'input-text'
     }, {
-      value: 'ho',
-      toggle: 'ho-reference',
-      child: 'input-text'
+      value: 'ho', toggle: 'ho-reference', child: 'input-text'
     }, {
-      value: 'ihs',
-      toggle: 'ihs-reference',
-      child: 'input-text'
+      value: 'ihs', toggle: 'ihs-reference', child: 'input-text'
     }, {
-      value: 'uan',
-      toggle: 'uan-reference',
-      child: 'input-text'
+      value: 'uan', toggle: 'uan-reference', child: 'input-text'
+    }, {
+      value: 'case-id', toggle: 'case-id-reference', child: 'input-text'
+    }, {
+      value: 'payment', toggle: 'payment-reference', child: 'input-text'
+    }, {
+      value: 'other', toggle: 'other-reference', child: 'input-text'
     }, {
       value: 'none'
     }]
-  },
-  'gwf-reference': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
-    dependent: {
-      field: 'reference-numbers',
-      value: 'gwf'
+  }, 'gwf-reference': {
+    validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}], dependent: {
+      field: 'reference-numbers', value: 'gwf'
     }
-  },
-  'ho-reference': {
+  }, 'ho-reference': {
     dependent: {
-      field: 'reference-numbers',
-      value: 'ho'
-    },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
-  },
-  'ihs-reference': {
+      field: 'reference-numbers', value: 'ho'
+    }, validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}]
+  }, 'ihs-reference': {
     dependent: {
-      field: 'reference-numbers',
-      value: 'ihs'
-    },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
-  },
-  'uan-reference': {
+      field: 'reference-numbers', value: 'ihs'
+    }, validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}]
+  }, 'uan-reference': {
     dependent: {
-      field: 'reference-numbers',
-      value: 'uan'
-    },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+      field: 'reference-numbers', value: 'uan'
+    }, validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}]
+  },
+  'case-id-reference': {
+    dependent: {
+      field: 'reference-numbers', value: 'case-id'
+    }, validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}]
+  },
+  'payment-reference': {
+    dependent: {
+      field: 'reference-numbers', value: 'payment'
+    }, validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}]
+  },
+  'other-reference': {
+    dependent: {
+      field: 'reference-numbers', value: 'other'
+    }, validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}]
   },
   'when-applied': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['']
+    }, className: ['']
   },
 
   'complaint-reference-number': {
-    mixin: 'input-text',
-    validate: ['notUrl', { type: 'maxlength', arguments: 100 }]
-  },
-  'complaint-details': {
+    mixin: 'input-text', validate: ['notUrl', {type: 'maxlength', arguments: 100}]
+  }, 'complaint-details': {
     mixin: 'textarea',
     attributes: [{
-      attribute: 'rows',
-      value: 12
+      attribute: 'rows', value: 12
     }],
-    validate: ['required', { type: 'maxlength', arguments: 50000 }],
+    validate: ['required', {type: 'maxlength', arguments: 50000}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     className: ['govuk-js-character-count']
   },
 
   'acting-as-agent': {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'yes',
-      'no'
-    ]
+    }, className: ['form-group'], options: ['yes', 'no']
   },
 
   'who-representing': {
-    mixin: 'radio-group',
-    validate: 'required',
-    options: [
-      'legal-rep',
-      'relative',
-      'sponsor',
-      'support-org'
-    ]
+    mixin: 'radio-group', validate: 'required', options: ['legal-rep', 'relative', 'sponsor', 'support-org']
   },
 
   'agent-name': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 150 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 150}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['']
+    }, className: ['']
   },
 
   'agent-email': {
-    mixin: 'input-text',
-    validate: ['required', 'email', { type: 'maxlength', arguments: 256 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'email', {type: 'maxlength', arguments: 256}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['']
+    }, className: ['']
   },
 
   'agent-phone': {
-    mixin: 'input-text',
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    mixin: 'input-text', validate: ['notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['govuk-input', 'govuk-input--width-20']
+    }, className: ['govuk-input', 'govuk-input--width-20']
   },
 
   'applicant-name': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['']
+    }, className: ['']
   },
 
   'applicant-dob': dateComponent('applicant-dob', {
-    mixin: 'input-date',
-    validate: [
-      'required',
-      'date',
-      { type: 'before', arguments: moment().subtract(18, 'years').format('YYYY-MM-DD') },
-      { type: 'after', arguments: '1900-01-01' }]
+    mixin: 'input-date', validate: ['required', 'date', {
+      type: 'before', arguments: moment().subtract(18, 'years').format('YYYY-MM-DD')
+    }, {type: 'after', arguments: '1900-01-01'}]
   }),
 
   'agent-representative-dob': dateComponent('agent-representative-dob', {
-    mixin: 'input-date',
-    validate: [
-      'required',
-      'date',
-      { type: 'before', arguments: moment().subtract(18, 'years').format('YYYY-MM-DD') },
-      { type: 'after', arguments: '1900-01-01' }]
+    mixin: 'input-date', validate: ['required', 'date', {
+      type: 'before', arguments: moment().subtract(18, 'years').format('YYYY-MM-DD')
+    }, {type: 'after', arguments: '1900-01-01'}]
   }),
 
   'applicant-email': {
-    mixin: 'input-text',
-    validate: ['required', 'email', { type: 'maxlength', arguments: 256 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'email', {type: 'maxlength', arguments: 256}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['']
+    }, className: ['']
   },
 
   'applicant-nationality': {
     mixin: 'select',
-    options: [{ label: ' ', value: '' }].concat(require('hof').utils.countries()),
+    options: [{label: ' ', value: ''}].concat(require('hof').utils.countries()),
     validate: 'required',
     className: ['typeahead']
   },
 
   'agent-representative-name': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
-    legend: {
+    mixin: 'input-text', validate: ['required', 'notUrl', {type: 'maxlength', arguments: 100}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['']
+    }, className: ['']
   },
 
   'agent-representative-nationality': {
     mixin: 'select',
-    options: [{ label: ' ', value: '' }].concat(require('hof').utils.countries()),
+    options: [{label: ' ', value: ''}].concat(require('hof').utils.countries()),
     validate: 'required',
     className: ['typeahead']
   },
 
   'applicant-phone': {
-    mixin: 'input-text',
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
-    legend: {
+    mixin: 'input-text', validate: ['notUrl', {type: 'maxlength', arguments: 50}], legend: {
       className: 'visuallyhidden'
-    },
-    className: ['govuk-input', 'govuk-input--width-20']
+    }, className: ['govuk-input', 'govuk-input--width-20']
   },
 
   where: {
-    mixin: 'radio-group',
-    validate: 'required',
-    legend: {
+    mixin: 'radio-group', validate: 'required', legend: {
       className: 'visuallyhidden'
-    },
-    className: ['form-group'],
-    options: [
-      'phone',
-      'visa-application-centre',
-      'premium-service-centre',
-      'letter'
-    ]
+    }, className: ['form-group'], options: ['phone', 'visa-application-centre', 'premium-service-centre', 'letter']
   }
 };

--- a/apps/ukvi-complaints/index.js
+++ b/apps/ukvi-complaints/index.js
@@ -365,7 +365,10 @@ module.exports = {
         'gwf-reference',
         'ho-reference',
         'ihs-reference',
-        'uan-reference'
+        'uan-reference',
+        'case-id-reference',
+        'payment-reference',
+        'other-reference'
       ],
       next: '/acting-as-agent'
     },
@@ -898,6 +901,9 @@ module.exports = {
           'ho-reference',
           'ihs-reference',
           'uan-reference',
+          'case-id-reference',
+          'payment-reference',
+          'other-reference',
           'complaint-details'
         ],
         'agent-details': [

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -150,6 +150,15 @@
       "uan": {
         "label": "Unique Application Number"
       },
+      "case-id": {
+        "label": "Case ID"
+      },
+      "payment": {
+        "label": "Payment reference number"
+      },
+      "other": {
+        "label": "Other reference number"
+      },
       "none": {
         "label": "I don’t have any of these "
       }
@@ -188,6 +197,30 @@
     "validation": {
       "required": "Enter the Unique Application Number",
       "notUrl": "Enter the Unique Application Number"
+    }
+  },
+  "case-id-reference": {
+    "label": "Enter your Case ID number",
+    "hint": null,
+    "validation": {
+      "required": "Enter your Case ID number",
+      "notUrl": "Enter your Case ID number"
+    }
+  },
+  "payment-reference": {
+    "label": "Enter your payment reference number",
+    "hint": null,
+    "validation": {
+      "required": "Enter your payment reference number",
+      "notUrl": "Enter your payment reference number"
+    }
+  },
+  "other-reference": {
+    "label": "Enter your reference number",
+    "hint": null,
+    "validation": {
+      "required": "Enter your reference number",
+      "notUrl": "Enter your reference number"
     }
   },
   "agent-representative-dob": {

--- a/apps/ukvi-complaints/translations/src/en/pages.json
+++ b/apps/ukvi-complaints/translations/src/en/pages.json
@@ -366,6 +366,15 @@
 			"uan-reference": {
 				"label": "Unique Application Number"
 			},
+      "case-id-reference": {
+        "label": "Enter your Case ID number"
+      },
+      "payment-reference": {
+        "label": "Enter your payment reference number"
+      },
+      "other-reference": {
+        "label": "Enter your reference number"
+      },
 			"none": {
 				"label": "I don’t have any of these"
       },

--- a/test/_unit/test-data/complaint-base.js
+++ b/test/_unit/test-data/complaint-base.js
@@ -6,6 +6,8 @@ const complaintDetailsBase = {
   'ho-reference': '',
   'ihs-reference': '',
   'uan-reference': '',
+  'case-id-reference': '',
+  'payment-reference': '',
   'acting-as-agent': 'no',
   'applicant-name': 'JJ',
   'applicant-dob': '1980-02-02',


### PR DESCRIPTION
Business have requested that additional options be made available in answer to the question "Which, if any, of the following reference numbers do you have?" in the Refund journey.

They would like:

Case ID
Any payment reference
Any other reference

to be added to the list of potential options.

Repo Changes:

- Added additional fields in fields.json and pages.json
- Append those fields inside fields array for url path /application-ref-numbers
- Add same reference validation style for added fields in fields/index.js

Reference:

https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-156