### PR TITLE
UKVIC-167: add new CSP rules to service config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-node:549b75f593f28da1c4a0a6f79877ec69d3b21037
+  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ settings.csp = {
     'https://region1.google-analytics.com',
     'https://region1.analytics.google.com'
   ]
-}
+};
 
 if (process.env.REDIS_URL) {
   settings.redis = process.env.REDIS_URL;

--- a/server.js
+++ b/server.js
@@ -6,6 +6,18 @@ const settings = require('./hof.settings');
 
 settings.routes = settings.routes.map(route => require(route));
 settings.root = __dirname;
+settings.csp = {
+  imgSrc: [
+    'www.google-analytics.com',
+    'ssl.gstatic.com',
+    'www.google.co.uk/ads/ga-audiences'
+  ],
+    connectSrc: [
+    'https://www.google-analytics.com',
+    'https://region1.google-analytics.com',
+    'https://region1.analytics.google.com'
+  ]
+}
 
 if (process.env.REDIS_URL) {
   settings.redis = process.env.REDIS_URL;

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ settings.csp = {
     'ssl.gstatic.com',
     'www.google.co.uk/ads/ga-audiences'
   ],
-    connectSrc: [
+  connectSrc: [
     'https://www.google-analytics.com',
     'https://region1.google-analytics.com',
     'https://region1.analytics.google.com'


### PR DESCRIPTION
## What

Add the following CSP rules to service config

imgSrc: [
      'www.google-analytics.com',
      'ssl.gstatic.com',
      'www.google.co.uk/ads/ga-audiences'
    ],
    connectSrc: [
      'https://www.google-analytics.com',
      'https://region1.google-analytics.com',
      'https://region1.analytics.google.com'
    ]

## Why

Support new GA analytics domain from https://region1.analytics.google.com to https://region1.google-analytics.com
