### PR TITLE
Upgrade HOF to v20.3.0 for Redis upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "aws4": "^1.11.0",
-    "hof": "^20.2.3",
+    "hof": "^20.3.11",
     "hot-shots": "^8.5.0",
     "jquery": "^3.6.0",
     "jsonschema": "^1.4.0",


### PR DESCRIPTION
## What?

update HOF package from v20.2.11 to v20.3.11 with tag _upgrade-redis-beta_

## Why?

Required to test newer version of Redis in UKVI form: https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-308
https://collaboration.homeoffice.gov.uk/jira/browse/UKVI-215

## How?

update version of hof in package.json

## Testing?

To be carried out by QAT team