### PR TITLE
Replace email module with Gov Notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Getting started
 
 The UKVI complaints service is a HOF app that users of UKVI can use to send complaints about their experience to the UKVI team.
+The service sends the complaint by email to the UKVI team and also a confirmation email to the user.
 The service has been integrated with the DECS case working system, by pushing each form submission to an AWS SQS queue which the DECS system will retrieve.
 
 Get the project from Github

--- a/apps/ukvi-complaints/behaviours/caseworker-email.js
+++ b/apps/ukvi-complaints/behaviours/caseworker-email.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const Emailer = require('hof').components.emailer;
+const hof = require('hof');
+const Notify = hof.components.notify;
 const path = require('path');
 const moment = require('moment');
 
@@ -140,7 +141,7 @@ const getDataRows = (model, translate) => {
           value: model['agent-name']
         },
         {
-          label: 'Agent’s relation to the applicant?',
+          label: 'Agent’s relation to the applicant',
           value: translate(`fields['who-representing'].options[${model['who-representing']}].label`)
         }
       ]
@@ -209,15 +210,7 @@ const getDataRows = (model, translate) => {
 };
 
 module.exports = config => {
-  if (config.transport !== 'stub' && !config.from && !config.replyTo) {
-    // eslint-disable-next-line no-console
-    console.warn('WARNING: Email `from` address must be provided. Falling back to stub email transport.');
-  }
-
-  const transport = config.emailCaseworker ? config.transport : 'stub';
-
-  return Emailer(Object.assign({}, config, {
-    transport: config.from ? transport : 'stub',
+  return Notify(Object.assign({}, config, {
     recipient: config.caseworker,
     subject: (model, translate) => translate('pages.email.caseworker.subject'),
     template: path.resolve(__dirname, '../emails/caseworker.html'),

--- a/apps/ukvi-complaints/behaviours/customer-email.js
+++ b/apps/ukvi-complaints/behaviours/customer-email.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const Emailer = require('hof').components.emailer;
+const hof = require('hof');
+const Notify = hof.components.notify;
 const path = require('path');
 const moment = require('moment');
 
@@ -140,7 +141,7 @@ const getDataRows = (model, translate) => {
           value: model['agent-name']
         },
         {
-          label: 'What is your relation to the applicant?',
+          label: 'What is your relation to the applicant',
           value: translate(`fields['who-representing'].options[${model['who-representing']}].label`)
         }
       ]
@@ -209,13 +210,7 @@ const getDataRows = (model, translate) => {
 };
 
 module.exports = config => {
-  if (config.transport !== 'stub' && !config.from && !config.replyTo) {
-    // eslint-disable-next-line no-console
-    console.warn('WARNING: Email `from` address must be provided. Falling back to stub email transport.');
-  }
-
-  return Emailer(Object.assign({}, config, {
-    transport: config.from ? config.transport : 'stub',
+  return Notify(Object.assign({}, config, {
     recipient: model => model['applicant-email'] || model['agent-email'] || 'noop@localhost',
     subject: (model, translate) => translate('pages.email.customer.subject'),
     template: path.resolve(__dirname, '../emails/customer.html'),

--- a/apps/ukvi-complaints/emails/caseworker.html
+++ b/apps/ukvi-complaints/emails/caseworker.html
@@ -1,21 +1,11 @@
+#A new UK Visas and Immigration complaint has been submitted
 
 {{#data}}
-  {{#title}}
-    <h3>{{title}}</h3>
-  {{/title}}
-  <table width="100%" cellspacing="0" cellpadding="0" rules="none">
-    {{#table}}
-      {{#linebreak}}
-      <tr>
-        <td colspan="2" style="border-bottom:1px solid #333;"></td>
-      </tr>
-      {{/linebreak}}
-      {{#value}}
-      <tr>
-        <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{label}}</td>
-        <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{value}}</td>
-      </tr>
-      {{/value}}
-    {{/table}}
-  </table>
+  #{{title}}
+  {{#table}}
+  {{#value}}
+    {{label}}: {{value}}
+  - - -
+  {{/value}}
+  {{/table}}
 {{/data}}

--- a/apps/ukvi-complaints/emails/customer.html
+++ b/apps/ukvi-complaints/emails/customer.html
@@ -1,28 +1,15 @@
-<p>We will investigate and provide a response within 20 working days.</p>
+We will investigate and provide a response within 20 working days.
 
 {{#data}}
-  {{#title}}
-    <h3>{{title}}</h3>
-  {{/title}}
-  <table width="100%" cellspacing="0" cellpadding="0" rules="none">
-    {{#table}}
-      {{#linebreak}}
-      <tr>
-        <td colspan="2" style="border-bottom:1px solid #333;"></td>
-      </tr>
-      {{/linebreak}}
-      {{#value}}
-      <tr>
-        <td width="40%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{label}}</td>
-        <td width="60%" style="padding: 15px 0;border-bottom:1px solid #ccc;">{{value}}</td>
-      </tr>
-      {{/value}}
-    {{/table}}
-  </table>
+  #{{title}}
+  {{#table}}
+  {{#value}}
+    {{label}}: {{value}}
+   - - -
+  {{/value}}
+  {{/table}}
 {{/data}}
 
-<div style="background:#ccc;padding: 0 20px 10px;border-top:5px solid #912B88;margin-top:20px;">
-  <h4>Further complaints</h4>
+  #Further complaints
 
-  <p>If you have another complaint about UK Visas and Immigration you can <a href="https://www.ukvi-complaints.homeoffice.gov.uk/">start a new complaint</a>.</p>
-</div>
+  If you have another complaint about UK Visas and Immigration you can [start a new complaint](https://www.ukvi-complaints.homeoffice.gov.uk/)

--- a/config.js
+++ b/config.js
@@ -9,22 +9,9 @@ module.exports = {
     password: process.env.REDIS_PASSWORD
   },
   email: {
-    from: process.env.FROM_ADDRESS,
-    replyTo: process.env.REPLY_TO,
-    transport: process.env.EMAIL_TRANSPORT || 'smtp',
-    caseworker: process.env.CASEWORKER_EMAIL || 'sas-hof-test@digital.homeoffice.gov.uk',
-    recipient: process.env.CASEWORKER_EMAIL || 'sas-hof-test@digital.homeoffice.gov.uk',
-    transportOptions: {
-      accessKeyId: process.env.HOF_SES_USER || process.env.AWS_USER || 'stub',
-      secretAccessKey: process.env.HOF_SES_PASSWORD || process.env.AWS_PASSWORD || 'stub',
-      host: process.env.EMAIL_HOST || 'email-smtp.eu-west-1.amazonaws.com',
-      port: process.env.EMAIL_PORT || 465,
-      auth: {
-        user: process.env.HOF_SES_USER || process.env.AWS_USER,
-        pass: process.env.HOF_SES_PASSWORD || process.env.AWS_PASSWORD
-      }
-    },
-    emailCaseworker: true
+    notifyApiKey: process.env.NOTIFY_KEY,
+    notifyTemplate: process.env.NOTIFY_TEMPLATE,
+    caseworker: process.env.CASEWORKER_EMAIL || 'sas-hof-test@digital.homeoffice.gov.uk'
   },
   hosts: {
     acceptanceTests: process.env.ACCEPTANCE_HOST_NAME || `http://localhost:${process.env.PORT || 8080}`

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -81,10 +81,10 @@ spec:
                   name: session-secret
                   key: token
             - name: NOTIFY_KEY
-               valueFrom:
-                 secretKeyRef:
-                   name: notify-key
-                   key: notify-key
+              valueFrom:
+                secretKeyRef:
+                  name: notify-key
+                  key: notify-key
             {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
             - name: SQS_URL
               valueFrom:

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -80,6 +80,11 @@ spec:
                 secretKeyRef:
                   name: session-secret
                   key: token
+            - name: NOTIFY_KEY
+               valueFrom:
+                 secretKeyRef:
+                   name: notify-key
+                   key: notify-key
             {{ if or (eq .KUBE_NAMESPACE .BRANCH_ENV) (eq .KUBE_NAMESPACE .UAT_ENV) }}
             - name: SQS_URL
               valueFrom:


### PR DESCRIPTION
**What**
Replace the email module Nodemailer with Gov Notify 

**Why**
The hof-emailer package uses a module which contains a high vulnerability (nodemailer-smtp-transport https://www.npmjs.com/package/nodemailer-smtp-transport). This package hasn't been updated in five years so uses a vulnerable version of lodash. 

**How**
Updated the service code and config to use the hof notify component for sending caseworker and confirmation emails

**Test**
Manual testing in local, branch and UAT. Unit tests and automated tests 