### PR TITLE
Updated configuration to switch off send to queue for staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ## Getting started
 
-The UKVI complaints service is a HOF app that users of UKVI can use to send complaints about their experience to the UKVI team.
-The service sends the complaint by email to the UKVI team and also a confirmation email to the user.
-The service has been integrated with the DECS case working system, by pushing each form submission to an AWS SQS queue which the DECS system will retrieve.
+The UKVI complaints service is a HOF app that users of UKVI can use to send complaints about their experience to the UKVI team. The service sends the complaint by email to the UKVI team and also a confirmation email to the user. The service has been integrated with the DECS case working system, by pushing each form submission to an AWS SQS queue which the DECS system will retrieve.
 
 Get the project from Github
 ```bash


### PR DESCRIPTION
**What**
Switch UKVIC staging send to queue to offline in hof-services-config

**Why**
The DECS prepared SQS is returning a InvalidClientTokenId error, there is no response from the DECS team to resolve the issue. This is preventing from testing the Gov Notify upgrade to UKVIC, so switching off the queue to enable testing.

**How**
Set SEND_TO_DECS_QUEUE to offline in hof-services-config 

**Test**
Manual testing in local, branch, uat and staging