### PR TITLE
UKVIC-217 & 218: Reference number validations

### DIFF
--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -438,7 +438,12 @@ module.exports = {
     }]
   },
   'gwf-reference': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }, { type: 'regex', arguments: /^GWF[0-9]{9}$/ }],
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'maxlength', arguments: 100 },
+      { type: 'regex', arguments: /^GWF[0-9]{9}$/ }
+    ],
     dependent: {
       field: 'reference-numbers',
       value: 'gwf'
@@ -456,14 +461,24 @@ module.exports = {
       field: 'reference-numbers',
       value: 'ihs'
     },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }, { type: 'regex', arguments: /^IHS[0-9]{9}$/ }]
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'maxlength', arguments: 100 },
+      { type: 'regex', arguments: /^IHS[0-9]{9}$/ }
+    ]
   },
   'uan-reference': {
     dependent: {
       field: 'reference-numbers',
       value: 'uan'
     },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }, { type: 'regex', arguments: /^\d{4}-\d{4}-\d{4}-\d{4}$/}]
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'maxlength', arguments: 100 },
+      { type: 'regex', arguments: /^\d{4}-\d{4}-\d{4}-\d{4}$/}
+    ]
   },
   'when-applied': {
     mixin: 'input-text',

--- a/apps/ukvi-complaints/fields/index.js
+++ b/apps/ukvi-complaints/fields/index.js
@@ -438,7 +438,7 @@ module.exports = {
     }]
   },
   'gwf-reference': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }, { type: 'regex', arguments: /^GWF[0-9]{9}$/ }],
     dependent: {
       field: 'reference-numbers',
       value: 'gwf'
@@ -449,21 +449,21 @@ module.exports = {
       field: 'reference-numbers',
       value: 'ho'
     },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'numeric', 'notUrl', { type: 'maxlength', arguments: 100 }]
   },
   'ihs-reference': {
     dependent: {
       field: 'reference-numbers',
       value: 'ihs'
     },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }, { type: 'regex', arguments: /^IHS[0-9]{9}$/ }]
   },
   'uan-reference': {
     dependent: {
       field: 'reference-numbers',
       value: 'uan'
     },
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }, { type: 'regex', arguments: /^\d{4}-\d{4}-\d{4}-\d{4}$/}]
   },
   'when-applied': {
     mixin: 'input-text',
@@ -476,7 +476,7 @@ module.exports = {
 
   'complaint-reference-number': {
     mixin: 'input-text',
-    validate: ['notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
   },
   'complaint-details': {
     mixin: 'textarea',

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -163,7 +163,8 @@
     "hint": "For example, GWF012345678.",
     "validation": {
       "required": "Enter the GWF number",
-      "notUrl": "Enter the GWF number"
+      "notUrl": "Enter the GWF number",
+      "regex": "Invalid GWF number. Please ensure the number starts with GWF followed by 9 digits"
     }
   },
   "ho-reference": {
@@ -171,6 +172,7 @@
     "hint": "For example, 012345678",
     "validation": {
       "required": "Enter the Home Office reference number",
+      "numeric": "Number must only contain digits",
       "notUrl": "Enter the Home Office reference number"
     }
   },
@@ -179,7 +181,8 @@
     "hint": "For example, IHS123456789",
     "validation": {
       "required": "Enter the IHS number",
-      "notUrl": "Enter the IHS number"
+      "notUrl": "Enter the IHS number",
+      "regex": "Invalid IHS number. Please ensure the number starts with IHS followed by 9 digits"
     }
   },
   "uan-reference": {
@@ -187,7 +190,8 @@
     "hint": "For example, 1234-5678-9123-4567",
     "validation": {
       "required": "Enter the Unique Application Number",
-      "notUrl": "Enter the Unique Application Number"
+      "notUrl": "Enter the Unique Application Number",
+      "regex": "Invalid UAN number. Please ensure your number follows the format: xxxx-xxxx-xxxx-xxxx"
     }
   },
   "agent-representative-dob": {
@@ -517,6 +521,7 @@
   "complaint-reference-number": {
     "label": " ",
     "validation": {
+      "required": "Please enter a reference number for your complaint",
       "notUrl": "Enter the reference number for your complaint "
     }
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:acceptance_browser": "ACCEPTANCE_WITH_BROWSER=true TAGS=\"${TAGS:=@feature}\" yarn run test:cucumber",
     "test:cucumber": "cucumber-js -f @cucumber/pretty-formatter \"test/_features/**/*.feature\" --require test/_features/test.setup.js --require \"test/_features/step_definitions/**/*.js\" --tags $TAGS",
     "test:cucumber-name": "cucumber-js -f @cucumber/pretty-formatter \"test/_features/**/*.feature\" --require test/_features/test.setup.js --require \"test/_features/step_definitions/**/*.js\" --name $NAME",
+    "test:cucumber:validations": "cucumber-js -f @cucumber/pretty-formatter \"test/_features/ukvi-complaints/validation.feature\" --require test/_features/test.setup.js --require \"test/_features/step_definitions/**/*.js\"",
     "sqs-setup": "docker build -q -t sqs-mock test/_integration/sqs-mock && docker run --name sqs-mock -p 9324:9324 -d sqs-mock",
     "sqs-cleanup": "docker stop sqs-mock && docker container rm sqs-mock",
     "test:snyk": "snyk config set api=SNYK_TOKEN && snyk test",

--- a/test/_features/step_definitions/steps.js
+++ b/test/_features/step_definitions/steps.js
@@ -107,5 +107,5 @@ Then('I should see {string} and {string} on the page', async function (key, valu
 
 Then('I should see the {string} error', async function (content) {
   await this.page.waitForSelector('body', { timeout: 15000 });
-  expect(await this.page.innerText('.validation-summary.error-summary')).to.include(content);
+  expect(await this.page.innerText('.govuk-error-summary')).to.include(content);
 }.bind(World));

--- a/test/_features/ukvi-complaints/validation.feature
+++ b/test/_features/ukvi-complaints/validation.feature
@@ -1,0 +1,49 @@
+@feature @validations
+Feature: Validations
+  A user should be see the appropriate validation error messages for each page
+
+  Scenario: Reference number validations
+    Given I start the 'reason' application journey
+    Then I should see 'What is the complaint about?' on the page
+    Then I check 'reason-staff-behaviour'
+    Then I select 'Continue'
+    Then I should be on the 'staff-behaviour' page showing 'Where did you experience poor behaviour?'
+    Then I check 'staff-behaviour-face-to-face'
+    Then I select 'Continue'
+    Then I should be on the 'face-to-face' page showing 'Where did the incident take place?'
+    Then I check 'which-centre-vac'
+    Then I select 'Continue'
+    Then I should be on the 'vac' page showing 'Where is the visa application centre?'
+    Then I fill 'vac-country' with 'United Kingdom' option
+    Then I fill 'vac-city' with 'London'
+    Then I select 'Continue'
+    Then I should be on the 'application-ref-numbers' page showing 'Which, if any, of the following reference numbers do you have?'
+    Then I check 'reference-numbers-gwf'
+    Then I select 'Continue'
+    Then I should see the 'Enter the GWF number' error
+    Then I fill 'gwf-reference' with ' 8GWF01234567'
+    Then I select 'Continue'
+    Then I should see the 'Invalid GWF number. Please ensure the number starts with GWF followed by 9 digits' error
+    Then I check 'reference-numbers-ho'
+    Then I select 'Continue'
+    Then I should see the 'Enter the Home Office reference number' error
+    Then I fill 'ho-reference' with '12345678S'
+    Then I select 'Continue'
+    Then I should see the 'Number must only contain digits' error
+    Then I check 'reference-numbers-ihs'
+    Then I select 'Continue'
+    Then I should see the 'Enter the IHS number' error
+    Then I fill 'ihs-reference' with 'IHS1234567'
+    Then I select 'Continue'
+    Then I should see the 'Invalid IHS number. Please ensure the number starts with IHS followed by 9 digits' error
+    Then I check 'reference-numbers-uan'
+    Then I select 'Continue'
+    Then I should see the 'Enter the Unique Application Number' error
+    Then I fill 'uan-reference' with '2092-122-1212'
+    Then I select 'Continue'
+    Then I should see the 'Invalid UAN number. Please ensure your number follows the format: xxxx-xxxx-xxxx-xxxx' error
+    Then I check 'reference-numbers-gwf'
+    Then I fill 'gwf-reference' with ' GWF012345678'
+    Then I select 'Continue'
+    Then I should be on the 'acting-as-agent' page
+


### PR DESCRIPTION
## What?

- Make field for question "What is the reference number for your complaint?" required
- Add regex validation for all reference numbers on /application-ref-numbers page
- Add relevant validation messages when refnumbers are invalid
- Add new acceptance tests for all reference number validations

## Why?

Bugs raised in:
https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-218
https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-217


## Testing?

All unit tests + acceptances tests passing locally

Testing completed on branch environment

## Screenshots (optional)
## Anything Else?