### PR TITLE
HOFF-642 Update UKVI-C to HOF v20.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "aws4": "^1.11.0",
-    "hof": "^20.2.3",
+    "hof": "^20.4.0",
     "hot-shots": "^8.5.0",
     "jquery": "^3.6.0",
     "jsonschema": "^1.4.0",


### PR DESCRIPTION
## What?
[HOFF-642 ](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-642).- changing Queen's crown to King's crown logo
 
## Why?
The Gov.uk crown logo changed
 
## How?
yarn install hof@20.4.0
 
## Testing?
Tested locally
 
## Screenshots (optional)
 
![Screenshot 2024-02-29 at 17 18 49](https://github.com/UKHomeOffice/ukvi-complaints/assets/138882912/692f8274-8ced-4298-a46f-b1b78cf0bfc4)
