### PR TITLE
UKVIC-246: Rearrange the order of kube deployments

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -27,16 +27,16 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
   $kd -f kube/redis -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
-  $kd -f kube/configmaps/configmap.yml -f kube/file-vault -f kube/app
-  $kd -f kube/redis
+  $kd -f kube/configmaps/configmap.yml 
+  $kd -f kube/redis -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/file-vault -f kube/app/service.yml
-  $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  $kd -f kube/redis -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
+  $kd -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
-  $kd -f kube/configmaps/configmap.yml -f kube/file-vault -f kube/app/service.yml
+  $kd -f kube/configmaps/configmap.yml -f kube/redis -f kube/file-vault -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  $kd -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY


### PR DESCRIPTION

## What?
* Redis pods required to be deployed ahead of other microservices


## Why?
* Many applications and services depend on Redis for caching, queuing, or session management. If Redis is deployed later, other services that rely on it might fail to start or experience downtime because they cannot access the Redis instance.
* Redis may require initialization of resources like persistent storage (which we are intending to add), replication setup, and network configurations. Deploying Redis first gives it time to initialize these resources and ensure they are ready before dependent services are started.
* Fixes Drone Pipeline issue
* rest of services are using the same order

## How?
* In deploy.sh ensure the redis deployment is added before the other deployments as seen in the commit

## Testing?
*
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
