### PR TITLE
[UKVIC 254] add missing validation messages

### DIFF
--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -481,6 +481,9 @@
   },
   "complaint-reason-previous": {
     "legend": " ",
+    "validation": {
+      "required": "Select what was your original complaint about"
+    },
     "options": {
       "immigration-application": {
         "label": "Submitting an application"
@@ -525,7 +528,8 @@
     "label": " ",
     "hint": "If you can't remember the exact date, just provide the month.",
     "validation": {
-      "notUrl": "Enter when you submitted you application "
+      "notUrl": "Enter when you submitted you application",
+      "required": "Enter when you submitted you application"
     }
   },
   "complaint-details": {

--- a/apps/ukvi-complaints/translations/src/en/fields.json
+++ b/apps/ukvi-complaints/translations/src/en/fields.json
@@ -482,7 +482,7 @@
   "complaint-reason-previous": {
     "legend": " ",
     "validation": {
-      "required": "Select what was your original complaint about"
+      "required": "Select what your original complaint was about"
     },
     "options": {
       "immigration-application": {
@@ -528,8 +528,8 @@
     "label": " ",
     "hint": "If you can't remember the exact date, just provide the month.",
     "validation": {
-      "notUrl": "Enter when you submitted you application",
-      "required": "Enter when you submitted you application"
+      "notUrl": "Enter when you submitted your application",
+      "required": "Enter when you submitted your application"
     }
   },
   "complaint-details": {


### PR DESCRIPTION
## What?
Validation error message missing on these UKVIC pages. Please see following ticket [UKVIC-254](https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-254)
## Why?
Bug identified
## How?
Added the validation messages in the fields.json file
## Testing?
Manual testing conducted
## Screenshots (optional)
![Screenshot 2025-04-09 at 11 38 40](https://github.com/user-attachments/assets/390184fe-5c3f-4265-ac54-67328aca8dff)
![Screenshot 2025-04-09 at 11 38 05](https://github.com/user-attachments/assets/aa4d8757-c644-4c90-9700-93b754331883)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
