### PR TITLE
UKVIC-268: Increase memory requests and limits

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -207,10 +207,10 @@ spec:
           resources:
             requests:
               cpu: "20m"
-              memory: "100Mi"
+              memory: "256Mi"
             limits:
               cpu: "100m"
-              memory: "200Mi"
+              memory: "512Mi"
           volumeMounts:
             - mountPath: /public
               name: public


### PR DESCRIPTION
## What?

* UKVIC amend form after the additions of Filevault and Keycloak has started consuming high memory
* It has exceeded the memory limits and resulted in pod restarts
* It has adverse effects on Form performance due to restarts
* Compared and added additional memory and limits to the UKVI-COMPLAINTS Container

## Why?

<img width="534" alt="image" src="https://github.com/user-attachments/assets/02c3b685-08e3-4f87-8442-7aea87bd4e8f" />
UKVI-Complaints has the lowest CPU and memory allocation across the services with similar system design. One of the reason could be the latest integration of Keycloak and File vault to the UKVIC amend form may be contributing to increased memory and CPU usage for eg Session management, Token validation, Encryption/decryption operations.

## How?


- Baseline memory: 256Mi (aligned with CSL/ACRS)
- Memory limit: 512Mi (to accommodate Keycloak/File Vault overhead)

## Testing?

Closely monitor in sysdig for any pod restarts and memory consumption. 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
