### PR TITLE
UKVIC-276: removing final paragraph of notify email template

### DIFF
--- a/apps/ukvi-complaints/emails/customer.html
+++ b/apps/ukvi-complaints/emails/customer.html
@@ -9,7 +9,3 @@ We will investigate and provide a response within 20 working days.
   {{/value}}
   {{/table}}
 {{/data}}
-
-  #Further complaints
-
-  If you have another complaint about UK Visas and Immigration you can [start a new complaint](https://www.ukvi-complaints.homeoffice.gov.uk/)


### PR DESCRIPTION
## What?
Remove the final paragraph in the email to the user after they submit the UKVIC form
## Why?
https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-276
## How?
## Testing?
## Screenshots (optional)
<img width="1250" height="804" alt="image" src="https://github.com/user-attachments/assets/11e7f39c-3352-42f2-afab-e192cd059dfe" />
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
