### PR TITLE
UKVIC 287 save form data into db

### DIFF
--- a/apps/ukvi-complaints/behaviours/save-form-session.js
+++ b/apps/ukvi-complaints/behaviours/save-form-session.js
@@ -42,10 +42,10 @@ module.exports = superclass => class extends superclass {
         return next();
       }
 
-      const submissionReference = req.sessionModel.get('submission-reference');
+      const submission_reference = req.sessionModel.get('submission-reference');
 
-      const params = this.requestBody({ submissionReference, session });
-      req.log('info', `Submission Reference: ${submissionReference}, Saving Form Session`);
+      const params = this.requestBody({ submission_reference, session });
+      req.log('info', `Submission Reference: ${submission_reference}, Saving Form Session`);
 
       try {
         const model = new Model();
@@ -58,7 +58,7 @@ module.exports = superclass => class extends superclass {
         }
         return next();
       } catch (e) {
-        req.log('info', `Submission Reference: ${submissionReference}, Error Saving Session: ${e}`);
+        req.log('info', `Submission Reference: ${submission_reference}, Error Saving Session: ${e}`);
         return next(e);
       }
     });

--- a/apps/ukvi-complaints/behaviours/save-form-session.js
+++ b/apps/ukvi-complaints/behaviours/save-form-session.js
@@ -1,0 +1,79 @@
+/* eslint-disable camelcase */
+
+const { model: Model } = require('hof');
+const config = require('../../../config');
+const applicationsUrl = `${config.saveService.host}:${config.saveService.port}/submitted_applications`;
+
+module.exports = superclass => class extends superclass {
+  requestBody(id, patchObj, postObj) {
+    if (id === undefined || id.length === 0) {
+      return {
+        url: applicationsUrl,
+        method: 'POST',
+        data: postObj
+      };
+    }
+
+    return {
+      url: applicationsUrl + `/${id}`,
+      method: 'PATCH',
+      data: patchObj
+    };
+  }
+
+  getSession(req) {
+    // remove csrf secret and errors from session data to prevent CSRF Secret issues in the session
+    const session = req.sessionModel.toJSON();
+    delete session['csrf-secret'];
+    delete session.errors;
+    delete session['valid-token'];
+    delete session['user-cases'];
+
+    if (session.steps.indexOf(req.path) === -1) {
+      session.steps.push(req.path);
+    }
+    // ensure no /edit steps are add to the steps property when we save to the store
+    session.steps = session.steps.filter(step => !step.match(/\/change|edit$/));
+
+    return session;
+  }
+
+  async saveValues(req, res, next) {
+    return super.saveValues(req, res, async err => {
+      if (err) {
+        return next(err);
+      }
+      const session = this.getSession(req);
+
+      // skip requesting data service api when running in local and test mode
+      if (config.env === 'local' || config.env === 'test') {
+        return next();
+      }
+
+      const id = req.sessionModel.get('id');
+      const submission_reference = req.sessionModel.get('submission-reference');
+
+      const params = this.requestBody(id, { session }, { submission_reference, session });
+      const submissionReference = req.sessionModel.get('submission-reference');
+      req.log('info', `Submission Reference: ${submissionReference}, Saving Form Session: ${id}`);
+
+      try {
+        const model = new Model();
+        const response = await model._request(params);
+        const resBody = response.data;
+
+        if (resBody && resBody.length && resBody[0].id) {
+          req.sessionModel.set('id', resBody[0].id);
+        } else {
+          const errorMessage = `Id hasn't been received in response ${JSON.stringify(response.data)}`;
+          req.log('error', errorMessage);
+          req.sessionModel.unset('id');
+        }
+        return next();
+      } catch (e) {
+        req.log('info', `Submission Reference: ${submissionReference}, Error Saving Session: ${e}`);
+        return next(e);
+      }
+    });
+  }
+};

--- a/apps/ukvi-complaints/behaviours/send-to-sqs.js
+++ b/apps/ukvi-complaints/behaviours/send-to-sqs.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Validator = require('jsonschema').Validator;
-const { v4: uuidv4 } = require('uuid');
 const config = require('../../../config');
 const { validAgainstSchema, sendToQueue } = require('../../../lib/utils');
 const formatComplaintData = require('../../../lib/format-complaint-data');
@@ -19,7 +18,7 @@ module.exports = superclass => class SendToSQS extends superclass {
         return next();
       }
 
-      complaintId = uuidv4();
+      complaintId = req.sessionModel.get('submission-reference');
       complaintData = formatComplaintData(req.sessionModel.attributes);
 
       if (validAgainstSchema(complaintData, new Validator())) {

--- a/apps/ukvi-complaints/behaviours/set-submission-reference.js
+++ b/apps/ukvi-complaints/behaviours/set-submission-reference.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = superclass => class extends superclass {
+  getValues(req, res, next) {
+    const submissionReference = req.sessionModel.get('submission-reference') || uuidv4();
+    req.sessionModel.set('submission-reference', submissionReference);
+    req.log('info', `Submission Reference: ${submissionReference} for application submission`);
+    return super.getValues(req, res, next);
+  }
+};

--- a/apps/ukvi-complaints/index.js
+++ b/apps/ukvi-complaints/index.js
@@ -888,7 +888,12 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: [sendToSQS, caseworkerEmailer, customerEmailer, 'complete', require('hof').components.summary, SaveFormSession],
+      behaviours: [sendToSQS,
+        caseworkerEmailer,
+        customerEmailer,
+        'complete',
+        require('hof').components.summary,
+        SaveFormSession],
       next: '/complete',
       sections: {
         'complaint-details': [

--- a/apps/ukvi-complaints/index.js
+++ b/apps/ukvi-complaints/index.js
@@ -888,12 +888,14 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: [sendToSQS,
+      behaviours: [
+        sendToSQS,
+        SaveFormSession,
         caseworkerEmailer,
         customerEmailer,
         'complete',
-        require('hof').components.summary,
-        SaveFormSession],
+        require('hof').components.summary
+      ],
       next: '/complete',
       sections: {
         'complaint-details': [

--- a/apps/ukvi-complaints/index.js
+++ b/apps/ukvi-complaints/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const config = require('../../config');
+const SetSubmissionReference = require('./behaviours/set-submission-reference');
 const conditionalContent = require('./behaviours/conditional-content');
 const customerEmailer = require('./behaviours/customer-email')(config.email);
 const caseworkerEmailer = require('./behaviours/caseworker-email')(config.email);
@@ -8,6 +9,7 @@ const SaveDocument = require('./behaviours/save-file');
 const RemoveDocument = require('./behaviours/remove-file');
 const sendToSQS = require('./behaviours/send-to-sqs');
 const ResetOnChange = require('./behaviours/reset-on-change');
+const SaveFormSession = require('./behaviours/save-form-session');
 
 module.exports = {
   name: 'ukvi-complaints',
@@ -19,7 +21,7 @@ module.exports = {
   steps: {
     '/reason': {
       fields: ['reason'],
-      behaviours: [ResetOnChange({ field: 'reason' })],
+      behaviours: [ResetOnChange({ field: 'reason' }), SetSubmissionReference],
       next: '/immigration-application',
       forks: [{
         target: '/immigration-application',
@@ -886,7 +888,7 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: [sendToSQS, caseworkerEmailer, customerEmailer, 'complete', require('hof').components.summary],
+      behaviours: [sendToSQS, caseworkerEmailer, customerEmailer, 'complete', require('hof').components.summary, SaveFormSession],
       next: '/complete',
       sections: {
         'complaint-details': [

--- a/config.js
+++ b/config.js
@@ -50,5 +50,10 @@ module.exports = {
     password: process.env.KEYCLOAK_PASSWORD,
     clientId: process.env.KEYCLOAK_CLIENT_ID,
     secret: process.env.KEYCLOAK_SECRET
+  },
+  saveService: {
+    port: process.env.DATASERVICE_SERVICE_PORT_HTTPS,
+    host: process.env.DATASERVICE_SERVICE_HOST &&
+      `https://${process.env.DATASERVICE_SERVICE_HOST}` || 'http://127.0.0.1'
   }
 };

--- a/test/_unit/behaviours/save-form-session.spec.js
+++ b/test/_unit/behaviours/save-form-session.spec.js
@@ -18,7 +18,7 @@ const ModelMock = {
 
 // Load SaveFormBehaviour with mocked hof
 const SaveFormBehaviour = proxyquire('../../../apps/ukvi-complaints/behaviours/save-form-session', {
-  'hof': ModelMock
+  hof: ModelMock
 });
 
 class MockSuperClass {
@@ -90,7 +90,9 @@ describe('save-form-session', () => {
   });
 
   describe('saveValues', () => {
-    let req, res, next;
+    let req;
+    let res;
+    let next;
 
     beforeEach(() => {
       req = {
@@ -141,7 +143,8 @@ describe('save-form-session', () => {
 
       await instance.saveValues(req, res, next);
       expect(req.sessionModel.unset.calledWith('id')).to.be.true;
-      expect(req.log.calledWithMatch('error', sinon.match((msg) => msg.includes("Id hasn't been received")))).to.be.true;
+      expect(req.log.calledWithMatch('error', sinon.match(
+        msg => msg.includes("Id hasn't been received")))).to.be.true;
     });
 
     it('should call next with error on request failure', async () => {

--- a/test/_unit/behaviours/save-form-session.spec.js
+++ b/test/_unit/behaviours/save-form-session.spec.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+const config = require('../../../config');
+
+// Mock hof and its model
+const mockRequestStub = sinon.stub();
+const ModelMock = {
+  model: function () {
+    return {
+      _request: mockRequestStub
+    };
+  }
+};
+
+// Load SaveFormBehaviour with mocked hof
+const SaveFormBehaviour = proxyquire('../../../apps/ukvi-complaints/behaviours/save-form-session', {
+  'hof': ModelMock
+});
+
+class MockSuperClass {
+  saveValues(req, res, next) {
+    return next();
+  }
+}
+
+const CustomClass = SaveFormBehaviour(MockSuperClass);
+const instance = new CustomClass();
+
+describe('save-form-session', () => {
+  describe('requestBody', () => {
+    it('should return POST request when id is undefined', () => {
+      const result = instance.requestBody(undefined, {}, { foo: 'bar' });
+      expect(result).to.deep.equal({
+        url: `${config.saveService.host}:${config.saveService.port}/submitted_applications`,
+        method: 'POST',
+        data: { foo: 'bar' }
+      });
+    });
+
+    it('should return PATCH request when id is provided', () => {
+      const result = instance.requestBody('123', { patch: true }, {});
+      expect(result).to.deep.equal({
+        url: `${config.saveService.host}:${config.saveService.port}/submitted_applications/123`,
+        method: 'PATCH',
+        data: { patch: true }
+      });
+    });
+  });
+
+  describe('getSession', () => {
+    it('should clean session and update steps', () => {
+      const req = {
+        path: '/step1',
+        sessionModel: {
+          toJSON: () => ({
+            'csrf-secret': 'secret',
+            errors: ['error'],
+            'valid-token': true,
+            'user-cases': [],
+            steps: []
+          })
+        }
+      };
+
+      const session = instance.getSession(req);
+      expect(session['csrf-secret']).to.be.undefined;
+      expect(session.errors).to.be.undefined;
+      expect(session['valid-token']).to.be.undefined;
+      expect(session['user-cases']).to.be.undefined;
+      expect(session.steps).to.include('/step1');
+    });
+
+    it('should filter out /edit and /change steps', () => {
+      const req = {
+        path: '/step2',
+        sessionModel: {
+          toJSON: () => ({
+            steps: ['/step1', '/step1/edit', '/step2/change']
+          })
+        }
+      };
+
+      const session = instance.getSession(req);
+      expect(session.steps).to.deep.equal(['/step1', '/step2']);
+    });
+  });
+
+  describe('saveValues', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+      req = {
+        sessionModel: {
+          get: sinon.stub().callsFake(key => {
+            const data = {
+              id: 'abc123',
+              'submission-reference': 'ref456'
+            };
+            return data[key];
+          }),
+          set: sinon.stub(),
+          unset: sinon.stub(),
+          toJSON: sinon.stub().returns({
+            'csrf-secret': 'value',
+            errors: 'value1',
+            'valid-token': 'value2',
+            'user-cases': 'value3',
+            steps: ['/step1', '/step2']
+          })
+        },
+        log: sinon.stub(),
+        path: '/step1'
+      };
+      res = {};
+      next = sinon.stub();
+      mockRequestStub.reset();
+    });
+
+    it('should skip saving in local/test env', async () => {
+      config.env = 'test';
+      await instance.saveValues(req, res, next);
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it('should call model._request and set id on success', async () => {
+      config.env = 'production';
+      mockRequestStub.resolves({ data: [{ id: 'new-id' }] });
+
+      await instance.saveValues(req, res, next);
+      expect(req.sessionModel.set.calledWith('id', 'new-id')).to.be.true;
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it('should unset id and log error if response is invalid', async () => {
+      config.env = 'production';
+      mockRequestStub.resolves({ data: [{}] });
+
+      await instance.saveValues(req, res, next);
+      expect(req.sessionModel.unset.calledWith('id')).to.be.true;
+      expect(req.log.calledWithMatch('error', sinon.match((msg) => msg.includes("Id hasn't been received")))).to.be.true;
+    });
+
+    it('should call next with error on request failure', async () => {
+      config.env = 'production';
+      const error = new Error('Request failed');
+      mockRequestStub.rejects(error);
+
+      await instance.saveValues(req, res, next);
+      expect(next.calledWith(error)).to.be.true;
+    });
+  });
+});

--- a/test/_unit/behaviours/send-to-sqs.spec.js
+++ b/test/_unit/behaviours/send-to-sqs.spec.js
@@ -30,19 +30,22 @@ describe('SendToSQS', () => {
   beforeEach(() => {
     req = {
       sessionModel: {
-        attributes: 'test attributes'
+        attributes: 'test attributes',
+        get: sinon.stub().withArgs('submission-reference').returns(testUuid)
       }
     };
 
     badReq = {
       sessionModel: {
-        attributes: 'bad attributes'
+        attributes: 'bad attributes',
+        get: sinon.stub().withArgs('submission-reference').returns(testUuid)
       }
     };
 
     badDataReq = {
       sessionModel: {
-        attributes: 'bad data'
+        attributes: 'bad data',
+        get: sinon.stub().withArgs('submission-reference').returns(testUuid)
       }
     };
 

--- a/test/_unit/behaviours/set-submission-reference.spec.js
+++ b/test/_unit/behaviours/set-submission-reference.spec.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { v4: uuidv4 } = require('uuid');
+
+const SetSubmissionReferenceBehaviour = require('../../../apps/ukvi-complaints/behaviours/set-submission-reference');
+
+describe('set-submission-reference', () => {
+  class Base {
+    getValues() {}
+  }
+
+  let req;
+  let res;
+  let next;
+  let instance;
+  let getValuesStub;
+
+  beforeEach(() => {
+    req = {
+      sessionModel: {
+        set: sinon.stub(),
+        get: sinon.stub()
+      },
+      log: sinon.stub()
+    };
+    res = {};
+    next = sinon.stub();
+
+    getValuesStub = sinon.stub(Base.prototype, 'getValues').callsFake((reqArg, resArg, nextArg) => reqArg);
+
+    const CustomClass = SetSubmissionReferenceBehaviour(Base);
+    instance = new CustomClass();
+  });
+
+  afterEach(() => {
+    getValuesStub.restore();
+  });
+
+  describe('getValues', () => {
+    it('should set the submission reference if it exists in session', () => {
+      const existingUuid = uuidv4();
+      req.sessionModel.get.withArgs('submission-reference').returns(existingUuid);
+
+      instance.getValues(req, res, next);
+
+      expect(req.sessionModel.get.calledWith('submission-reference')).to.be.true;
+      expect(req.sessionModel.set.calledWith('submission-reference', existingUuid)).to.be.true;
+      expect(req.log.calledWithMatch('info', sinon.match((msg) => msg.includes(existingUuid)))).to.be.true;
+    });
+
+    it('should generate and set a new submission reference if not in session', () => {
+      req.sessionModel.get.withArgs('submission-reference').returns(undefined);
+
+      instance.getValues(req, res, next);
+
+      expect(req.sessionModel.set.calledWithMatch('submission-reference', sinon.match.string)).to.be.true;
+      expect(req.log.calledWithMatch('info', sinon.match((msg) => msg.includes('Submission Reference:')))).to.be.true;
+    });
+  });
+});

--- a/test/_unit/behaviours/set-submission-reference.spec.js
+++ b/test/_unit/behaviours/set-submission-reference.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { expect } = require('chai');
-const sinon = require('sinon');
 const { v4: uuidv4 } = require('uuid');
 
 const SetSubmissionReferenceBehaviour = require('../../../apps/ukvi-complaints/behaviours/set-submission-reference');

--- a/test/_unit/behaviours/set-submission-reference.spec.js
+++ b/test/_unit/behaviours/set-submission-reference.spec.js
@@ -28,7 +28,8 @@ describe('set-submission-reference', () => {
     res = {};
     next = sinon.stub();
 
-    getValuesStub = sinon.stub(Base.prototype, 'getValues').callsFake((reqArg, resArg, nextArg) => reqArg);
+    // getValuesStub = sinon.stub(Base.prototype, 'getValues').callsFake((reqArg, resArg, nextArg) => reqArg);
+    getValuesStub = sinon.stub(Base.prototype, 'getValues').callsFake(reqArg => reqArg);
 
     const CustomClass = SetSubmissionReferenceBehaviour(Base);
     instance = new CustomClass();
@@ -47,7 +48,7 @@ describe('set-submission-reference', () => {
 
       expect(req.sessionModel.get.calledWith('submission-reference')).to.be.true;
       expect(req.sessionModel.set.calledWith('submission-reference', existingUuid)).to.be.true;
-      expect(req.log.calledWithMatch('info', sinon.match((msg) => msg.includes(existingUuid)))).to.be.true;
+      expect(req.log.calledWithMatch('info', sinon.match(msg => msg.includes(existingUuid)))).to.be.true;
     });
 
     it('should generate and set a new submission reference if not in session', () => {
@@ -56,7 +57,7 @@ describe('set-submission-reference', () => {
       instance.getValues(req, res, next);
 
       expect(req.sessionModel.set.calledWithMatch('submission-reference', sinon.match.string)).to.be.true;
-      expect(req.log.calledWithMatch('info', sinon.match((msg) => msg.includes('Submission Reference:')))).to.be.true;
+      expect(req.log.calledWithMatch('info', sinon.match(msg => msg.includes('Submission Reference:')))).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## What?
As part of CSV export task, we need to save session form data into the ukvic database.

## Why?
[https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-287](https://collaboration.homeoffice.gov.uk/jira/browse/UKVIC-287)
## How?
Added saveformsession and submission-reference behaviour pages and its unit tests. Also fixed send to sqs page for submission-reference. Submitted_at field just added before submit form.

## Testing?
Tested but few limitations now due to secret rotations.

## Screenshots (optional)
Database saved data samples from my local.
<img width="1274" height="118" alt="image" src="https://github.com/user-attachments/assets/9e3f6d6c-d60a-4645-80ff-0fc8618f6a18" />

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
